### PR TITLE
Made pulp compile for more versions of Scala

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: scala
 scala:
-   - 2.12.2
+   - 2.11.5
+   - 2.11.12
+   - 2.12.0
    - 2.12.4
 jdk:
   - openjdk8

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ val versions = new {
 val settings = Seq(
   version := "0.0.3-SNAPSHOT",
   scalaVersion := versions.scalaVersion,
-  crossScalaVersions := Seq("2.12.4"),
+  crossScalaVersions := Seq("2.11.12", "2.12.4"),
   scalacOptions ++= Seq(
     "-target:jvm-1.8",
     "-encoding",
@@ -47,7 +47,7 @@ val settings = Seq(
     "-Xexperimental"
   ),
   scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
 val dependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ val settings = Seq(
     "-language:higherKinds",
     "-language:implicitConversions",
     "-Yno-adapted-args",
-    "-Ypartial-unification",
     "-Ywarn-dead-code",
     "-Ywarn-inaccessible",
     "-Ywarn-infer-any",

--- a/pulp/src/main/scala/io/scalaland/pulp/Provider.scala
+++ b/pulp/src/main/scala/io/scalaland/pulp/Provider.scala
@@ -1,8 +1,7 @@
 package io.scalaland.pulp
 
-import scala.annotation.{implicitAmbiguous, implicitNotFound}
+import scala.annotation.implicitNotFound
 
-@implicitAmbiguous("Provider[${A}] is ambiguous - check your scope for redundant Provider[$A] val/def")
 @implicitNotFound("Provider[${A}] not found, add annotation to ${A} or provide implicit Providers for constructor args")
 trait Provider[A] {
 


### PR DESCRIPTION
* downgrade of macro paradise to version supported by more Scala version
* cross build with Scala 2.11.5+
* removal of `@ambiguousImplicit` annotation available only on 2.12.0-M3+